### PR TITLE
fix takeover high risk list

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -16,7 +16,6 @@ var TakeOverList = []string{
 	".trafficmanager.net",
 	".azureedge.net",
 	".cloudapp.azure.com",
-	".cloudfront.net",
 	".s3.amazonaws.com",
 	".awsptr.com",
 	".elasticbeanstalk.com",


### PR DESCRIPTION
cloudfrontのテイクオーバーは不可のため、リストから削除します