### PR TITLE
Integrate log and trace

### DIFF
--- a/src/osint/backend_sqs.go
+++ b/src/osint/backend_sqs.go
@@ -57,7 +57,7 @@ func (s *sqsClient) send(ctx context.Context, msg *message.OsintQueueMessage) (*
 	}
 	buf, err := json.Marshal(msg)
 	if err != nil {
-		appLogger.Errorf("Failed to parse message error: %v", err)
+		appLogger.Errorf(ctx, "Failed to parse message error: %v", err)
 		return nil, fmt.Errorf("Failed to parse message, err=%+v", err)
 	}
 	resp, err := s.svc.SendMessageWithContext(ctx, &sqs.SendMessageInput{
@@ -66,7 +66,7 @@ func (s *sqsClient) send(ctx context.Context, msg *message.OsintQueueMessage) (*
 		DelaySeconds: aws.Int64(1),
 	})
 	if err != nil {
-		appLogger.Errorf("Failed to send message, error: %v ", err)
+		appLogger.Errorf(ctx, "Failed to send message, error: %v ", err)
 		return nil, err
 	}
 	return resp, nil

--- a/src/osint/client.go
+++ b/src/osint/client.go
@@ -13,7 +13,7 @@ func newProjectClient(svcAddr string) project.ProjectServiceClient {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf("Faild to get GRPC connection: err=%+v", err)
+		appLogger.Fatalf(ctx, "Failed to get GRPC connection: err=%+v", err)
 	}
 	return project.NewProjectServiceClient(conn)
 }

--- a/src/osint/go.mod
+++ b/src/osint/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/aws/aws-sdk-go v1.40.48
 	github.com/ca-risken/common/pkg/database v0.0.0-20220421051518-d57cbf184097
-	github.com/ca-risken/common/pkg/logging v0.0.0-20220113015330-0e8462d52b5b
+	github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27
 	github.com/ca-risken/common/pkg/rpc v0.0.0-20220113015330-0e8462d52b5b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20220421051518-d57cbf184097
@@ -53,7 +53,7 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/tinylib/msgp v1.1.2 // indirect
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309 // indirect
-	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/src/osint/go.mod
+++ b/src/osint/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ca-risken/common/pkg/database v0.0.0-20220421051518-d57cbf184097
 	github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27
-	github.com/ca-risken/common/pkg/rpc v0.0.0-20220113015330-0e8462d52b5b
+	github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20220421051518-d57cbf184097
 	github.com/ca-risken/core/proto/project v0.0.0-20220127020945-063d14f397ed
 	github.com/ca-risken/osint/pkg/message v0.0.0-20211112065816-37550cc4192d

--- a/src/osint/go.sum
+++ b/src/osint/go.sum
@@ -99,8 +99,8 @@ github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d/go.mod h1:H0wQ
 github.com/ca-risken/common/pkg/database v0.0.0-20220421051518-d57cbf184097 h1:bD6VclHqbTFzR+qc8Ns/WIzxaw1lJl9i37la8eahWCM=
 github.com/ca-risken/common/pkg/database v0.0.0-20220421051518-d57cbf184097/go.mod h1:n1VKFIhMlKCmSzc7Izgz+aH24ihR3K6yPDaNrTEFEGo=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220113014249-f285e209578f/go.mod h1:dmZZ5/wkGbsmAMbhuC7YK6uJOMAlS4OndoM0DQyPhi8=
-github.com/ca-risken/common/pkg/logging v0.0.0-20220113015330-0e8462d52b5b h1:3Mn6kwDX2mISoCGdF/eYcfpGS0m6d17Z8t8HSl6s1bQ=
-github.com/ca-risken/common/pkg/logging v0.0.0-20220113015330-0e8462d52b5b/go.mod h1:dmZZ5/wkGbsmAMbhuC7YK6uJOMAlS4OndoM0DQyPhi8=
+github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd h1:YXyIsRQNxpjNT3QaqYSU/RW7nA8HWh66EIE69yc0w/I=
+github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd/go.mod h1:iqLbvDuf708TWjF8RO5qw6Nx1e3R0/UEHZ8tE/VEPjA=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27 h1:NV95obXJwovUBvxWPW5boJcMAwkUIrsqhH3uwhTfTNY=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27/go.mod h1:xldq3VZ7qomkI5vfpw8Y9qCVEFl8BrSvDr+sxbz32H4=
 github.com/ca-risken/common/pkg/rpc v0.0.0-20220113015330-0e8462d52b5b h1:Bku8qY0JoN4u+OgnFF+t5rzdgi7zp3e1vWL088g+cnQ=
@@ -976,8 +976,9 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220111092808-5a964db01320/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 h1:nhht2DYV/Sn3qOayu8lM+cU1ii9sTLUeBQwQQfUHtrs=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/src/osint/go.sum
+++ b/src/osint/go.sum
@@ -98,13 +98,13 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/ca-risken/common/pkg/database v0.0.0-20220421051518-d57cbf184097 h1:bD6VclHqbTFzR+qc8Ns/WIzxaw1lJl9i37la8eahWCM=
 github.com/ca-risken/common/pkg/database v0.0.0-20220421051518-d57cbf184097/go.mod h1:n1VKFIhMlKCmSzc7Izgz+aH24ihR3K6yPDaNrTEFEGo=
-github.com/ca-risken/common/pkg/logging v0.0.0-20220113014249-f285e209578f/go.mod h1:dmZZ5/wkGbsmAMbhuC7YK6uJOMAlS4OndoM0DQyPhi8=
+github.com/ca-risken/common/pkg/logging v0.0.0-20220517105456-de734080357a/go.mod h1:iqLbvDuf708TWjF8RO5qw6Nx1e3R0/UEHZ8tE/VEPjA=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd h1:YXyIsRQNxpjNT3QaqYSU/RW7nA8HWh66EIE69yc0w/I=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd/go.mod h1:iqLbvDuf708TWjF8RO5qw6Nx1e3R0/UEHZ8tE/VEPjA=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27 h1:NV95obXJwovUBvxWPW5boJcMAwkUIrsqhH3uwhTfTNY=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27/go.mod h1:xldq3VZ7qomkI5vfpw8Y9qCVEFl8BrSvDr+sxbz32H4=
-github.com/ca-risken/common/pkg/rpc v0.0.0-20220113015330-0e8462d52b5b h1:Bku8qY0JoN4u+OgnFF+t5rzdgi7zp3e1vWL088g+cnQ=
-github.com/ca-risken/common/pkg/rpc v0.0.0-20220113015330-0e8462d52b5b/go.mod h1:A5WmKMV58G2v1s/oNXIzFsd9SiS8YxkkEWT3U6+yPd0=
+github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd h1:rrkuvylG4Etubw0miHpNnWje4VR5ZPUGR8FPmJWNwck=
+github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd/go.mod h1:fnvFF8ESVirs5LV36leyFKf3FbuqjLDhJnipGJgDZtA=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20220421051518-d57cbf184097 h1:kz1mALLbChWS0inQct+rQUpTgCEM5+XL5bzIjmMguF8=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20220421051518-d57cbf184097/go.mod h1:PIXjETIPseBEB/OXp5Rxn8FFuRwfQjFZe1VN+0Skh2E=
 github.com/ca-risken/core/proto/project v0.0.0-20220127020945-063d14f397ed h1:pOWNxFvFncNe24u0W3FMRLCdva0SQ7G0O0zs735+rq0=
@@ -346,7 +346,6 @@ github.com/google/pprof v0.0.0-20210423192551-a2663126120b/go.mod h1:kpwsk12EmLe
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -975,7 +974,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220111092808-5a964db01320/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/src/osint/main.go
+++ b/src/osint/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -58,19 +59,20 @@ type AppConfig struct {
 }
 
 func main() {
+	ctx := context.Background()
 	var conf AppConfig
 	err := envconfig.Process("", &conf)
 	if err != nil {
-		appLogger.Fatal(err)
+		appLogger.Fatal(ctx, err)
 	}
 
 	pTypes, err := profiler.ConvertProfileTypeFrom(conf.ProfileTypes)
 	if err != nil {
-		appLogger.Fatal(err.Error())
+		appLogger.Fatal(ctx, err.Error())
 	}
 	pExporter, err := profiler.ConvertExporterTypeFrom(conf.ProfileExporter)
 	if err != nil {
-		appLogger.Fatal(err.Error())
+		appLogger.Fatal(ctx, err.Error())
 	}
 	pc := profiler.Config{
 		ServiceName:  getFullServiceName(),
@@ -80,7 +82,7 @@ func main() {
 	}
 	err = pc.Start()
 	if err != nil {
-		appLogger.Fatal(err.Error())
+		appLogger.Fatal(ctx, err.Error())
 	}
 	defer pc.Stop()
 
@@ -117,7 +119,7 @@ func main() {
 
 	l, err := net.Listen("tcp", fmt.Sprintf(":%s", conf.Port))
 	if err != nil {
-		appLogger.Errorf("Failed to Opening Port. error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Opening Port. error: %v", err)
 	}
 
 	server := grpc.NewServer(
@@ -128,8 +130,8 @@ func main() {
 	osint.RegisterOsintServiceServer(server, service)
 
 	reflection.Register(server) // enable reflection API
-	appLogger.Infof("Starting gRPC server, port: %v", conf.Port)
+	appLogger.Infof(ctx, "Starting gRPC server, port: %v", conf.Port)
 	if err := server.Serve(l); err != nil {
-		appLogger.Errorf("Failed to gRPC server, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to gRPC server, error: %v", err)
 	}
 }

--- a/src/osint/main.go
+++ b/src/osint/main.go
@@ -125,8 +125,8 @@ func main() {
 	server := grpc.NewServer(
 		grpc.UnaryInterceptor(
 			grpcmiddleware.ChainUnaryServer(
-				mimosarpc.LoggingUnaryServerInterceptor(appLogger),
-				grpctrace.UnaryServerInterceptor())))
+				grpctrace.UnaryServerInterceptor(),
+				mimosarpc.LoggingUnaryServerInterceptor(appLogger))))
 	osint.RegisterOsintServiceServer(server, service)
 
 	reflection.Register(server) // enable reflection API

--- a/src/osint/services_detect_word.go
+++ b/src/osint/services_detect_word.go
@@ -19,7 +19,7 @@ func (s *osintService) ListOsintDetectWord(ctx context.Context, req *osint.ListO
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &osint.ListOsintDetectWordResponse{}, nil
 		}
-		appLogger.Errorf("Failed to List OsintDetectWord, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to List OsintDetectWord, error: %v", err)
 		return nil, err
 	}
 	data := osint.ListOsintDetectWordResponse{}
@@ -38,7 +38,7 @@ func (s *osintService) GetOsintDetectWord(ctx context.Context, req *osint.GetOsi
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &osint.GetOsintDetectWordResponse{}, nil
 		}
-		appLogger.Errorf("Failed to Get OsintDetectWord, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get OsintDetectWord, error: %v", err)
 		return nil, err
 	}
 
@@ -59,7 +59,7 @@ func (s *osintService) PutOsintDetectWord(ctx context.Context, req *osint.PutOsi
 
 	registerdData, err := s.repository.UpsertOsintDetectWord(ctx, data)
 	if err != nil {
-		appLogger.Errorf("Failed to Put OsintDetectWord, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Put OsintDetectWord, error: %v", err)
 		return nil, err
 	}
 	return &osint.PutOsintDetectWordResponse{OsintDetectWord: convertOsintDetectWord(registerdData)}, nil
@@ -70,7 +70,7 @@ func (s *osintService) DeleteOsintDetectWord(ctx context.Context, req *osint.Del
 		return nil, err
 	}
 	if err := s.repository.DeleteOsintDetectWord(ctx, req.ProjectId, req.OsintDetectWordId); err != nil {
-		appLogger.Errorf("Failed to Delete OsintDetectWord, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Delete OsintDetectWord, error: %v", err)
 		return nil, err
 	}
 	return &empty.Empty{}, nil

--- a/src/osint/services_osint.go
+++ b/src/osint/services_osint.go
@@ -19,7 +19,7 @@ func (s *osintService) ListOsint(ctx context.Context, req *osint.ListOsintReques
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &osint.ListOsintResponse{}, nil
 		}
-		appLogger.Errorf("Failed to List Osint. error: %v", err)
+		appLogger.Errorf(ctx, "Failed to List Osint. error: %v", err)
 		return nil, err
 	}
 	data := osint.ListOsintResponse{}
@@ -38,7 +38,7 @@ func (s *osintService) GetOsint(ctx context.Context, req *osint.GetOsintRequest)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &osint.GetOsintResponse{}, nil
 		}
-		appLogger.Errorf("Failed to Get Osint. error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get Osint. error: %v", err)
 		return nil, err
 	}
 
@@ -59,7 +59,7 @@ func (s *osintService) PutOsint(ctx context.Context, req *osint.PutOsintRequest)
 
 	registerdData, err := s.repository.UpsertOsint(ctx, data)
 	if err != nil {
-		appLogger.Errorf("Failed to Put Osint. error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Put Osint. error: %v", err)
 		return nil, err
 	}
 	return &osint.PutOsintResponse{Osint: convertOsint(registerdData)}, nil
@@ -71,19 +71,19 @@ func (s *osintService) DeleteOsint(ctx context.Context, req *osint.DeleteOsintRe
 	}
 	relOsintDataSources, err := s.repository.ListRelOsintDataSource(ctx, req.ProjectId, req.OsintId, 0)
 	if err != nil {
-		appLogger.Errorf("Failed to List RelOsintDataSource when delete osint. error: %v", err)
+		appLogger.Errorf(ctx, "Failed to List RelOsintDataSource when delete osint. error: %v", err)
 		return nil, err
 	}
 
 	for _, relOsintDataSource := range *relOsintDataSources {
 		if err := s.deleteRelOsintDataSourceWithDetectWord(ctx, relOsintDataSource.ProjectID, relOsintDataSource.RelOsintDataSourceID); err != nil {
-			appLogger.Errorf("Failed to DeleteRelOsintDataSource. error: %v", err)
+			appLogger.Errorf(ctx, "Failed to DeleteRelOsintDataSource. error: %v", err)
 			return nil, err
 		}
 	}
 
 	if err := s.repository.DeleteOsint(ctx, req.ProjectId, req.OsintId); err != nil {
-		appLogger.Errorf("Failed to DeleteOsint. error: %v", err)
+		appLogger.Errorf(ctx, "Failed to DeleteOsint. error: %v", err)
 		return nil, err
 	}
 	return &empty.Empty{}, nil

--- a/src/osint/services_osint_datasource.go
+++ b/src/osint/services_osint_datasource.go
@@ -19,7 +19,7 @@ func (s *osintService) ListOsintDataSource(ctx context.Context, req *osint.ListO
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &osint.ListOsintDataSourceResponse{}, nil
 		}
-		appLogger.Errorf("Failed to List OsintDataSource, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to List OsintDataSource, error: %v", err)
 		return nil, err
 	}
 	data := osint.ListOsintDataSourceResponse{}
@@ -38,7 +38,7 @@ func (s *osintService) GetOsintDataSource(ctx context.Context, req *osint.GetOsi
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &osint.GetOsintDataSourceResponse{}, nil
 		}
-		appLogger.Errorf("Failed to Get OsintDataSource, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get OsintDataSource, error: %v", err)
 		return nil, err
 	}
 
@@ -59,7 +59,7 @@ func (s *osintService) PutOsintDataSource(ctx context.Context, req *osint.PutOsi
 
 	registerdData, err := s.repository.UpsertOsintDataSource(ctx, data)
 	if err != nil {
-		appLogger.Errorf("Failed to Put OsintDataSource, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Put OsintDataSource, error: %v", err)
 		return nil, err
 	}
 	return &osint.PutOsintDataSourceResponse{OsintDataSource: convertOsintDataSource(registerdData)}, nil
@@ -70,7 +70,7 @@ func (s *osintService) DeleteOsintDataSource(ctx context.Context, req *osint.Del
 		return nil, err
 	}
 	if err := s.repository.DeleteOsintDataSource(ctx, req.ProjectId, req.OsintDataSourceId); err != nil {
-		appLogger.Errorf("Failed to Delete OsintDataSource, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Delete OsintDataSource, error: %v", err)
 		return nil, err
 	}
 	return &empty.Empty{}, nil


### PR DESCRIPTION
osintサービスのみログとトレースの統合を対応しました。
アクセスログに同様の処理を行うためインタセプターの順序を入れ替えています。

worker系のサービスはaws-sdk-goのバージョンアップが必要になるため、別のPRに切り出す予定です。