### PR TITLE
fix website tag

### DIFF
--- a/src/website/finding.go
+++ b/src/website/finding.go
@@ -50,8 +50,8 @@ func (s *SQSHandler) putFinding(ctx context.Context, websiteFinding *finding.Fin
 	if err = s.tagFinding(ctx, res.Finding.ProjectId, res.Finding.FindingId, common.TagWebsite); err != nil {
 		appLogger.Errorf(ctx, "Failed to tag finding. tag: %v, error: %v", common.TagWebsite, err)
 	}
-	if err = s.tagFinding(ctx, res.Finding.ProjectId, res.Finding.FindingId, msg.ResourceName); err != nil {
-		appLogger.Errorf(ctx, "Failed to tag finding. tag: %v, error: %v", msg.ResourceName, err)
+	if err = s.tagFinding(ctx, res.Finding.ProjectId, res.Finding.FindingId, fmt.Sprintf("osint_id:%v", msg.OsintID)); err != nil {
+		appLogger.Errorf(ctx, "Failed to tag finding. tag: %v, error: %v", fmt.Sprintf("osint_id:%v", msg.OsintID), err)
 		return err
 	}
 

--- a/src/website/handler.go
+++ b/src/website/handler.go
@@ -65,7 +65,7 @@ func (s *SQSHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 	if _, err := s.findingClient.ClearScore(ctx, &finding.ClearScoreRequest{
 		DataSource: msg.DataSource,
 		ProjectId:  msg.ProjectID,
-		Tag:        []string{msg.ResourceName},
+		Tag:        []string{fmt.Sprintf("osint_id:%v", msg.OsintID)},
 	}); err != nil {
 		appLogger.Errorf(ctx, "Failed to clear finding score. ResourceName: %v, error: %v", msg.ResourceName, err)
 		return s.handleErrorWithUpdateStatus(ctx, msg, err)


### PR DESCRIPTION
URLを含めた際に、タグの文字長制限を超えてエラーが発生する場合があったので以下の修正を行います
- URLをタグで登録しない
- OsintIDをタグに登録することで、スキャンごとに一意な検索を可能にする