### PR TITLE
Improve error handling in subdomain

### DIFF
--- a/src/subdomain/certificate_expiration.go
+++ b/src/subdomain/certificate_expiration.go
@@ -27,6 +27,7 @@ func (p *privateExpose) checkCertificateExpiration() certificateExpiration {
 
 func checkCertificateExpiration(url string) time.Time {
 	client := &http.Client{}
+	// Only normally accessible URLs, exclude temporarily inaccessible URLs ex. service unavailable, are scanned, so error is ignored.
 	req, _ := http.NewRequest("GET", url, nil)
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse

--- a/src/subdomain/client.go
+++ b/src/subdomain/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/alert"
@@ -11,31 +12,28 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
-	ctx := context.Background()
+func newFindingClient(ctx context.Context, svcAddr string) (finding.FindingServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
-	ctx := context.Background()
+func newAlertClient(ctx context.Context, svcAddr string) (alert.AlertServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newOsintClient(svcAddr string) osint.OsintServiceClient {
-	ctx := context.Background()
+func newOsintClient(ctx context.Context, svcAddr string) (osint.OsintServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return osint.NewOsintServiceClient(conn)
+	return osint.NewOsintServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/src/subdomain/harvester.go
+++ b/src/subdomain/harvester.go
@@ -81,6 +81,7 @@ func makeHosts(hostsWithIP *hostsWithIP, hostsWithoutIP *hostsWithoutIP, domain 
 }
 
 func getIPAddr(domain string) string {
+	// Only normally accessible domains, exclude temporarily inaccessible ex. service unavailable, are scanned, so error is ignored.
 	ips, _ := net.LookupIP(domain)
 	for _, ip := range ips {
 		return ip.String()

--- a/src/subdomain/main.go
+++ b/src/subdomain/main.go
@@ -125,7 +125,10 @@ func main() {
 		MaxNumberOfMessage: conf.MaxNumberOfMessage,
 		WaitTimeSecond:     conf.WaitTimeSecond,
 	}
-	consumer := newSQSConsumer(ctx, sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create SQS consumer, err=%+v", err)
+	}
 	appLogger.Info(ctx, "Start the subdomain SQS consumer server...")
 	consumer.Start(ctx,
 		mimosasqs.InitializeHandler(

--- a/src/subdomain/main.go
+++ b/src/subdomain/main.go
@@ -84,17 +84,26 @@ func main() {
 	tracer.Start(tc)
 	defer tracer.Stop()
 
-	handler := &SQSHandler{}
-	handler.harvesterConfig = newHarvesterConfig(conf.ResultPath, conf.HarvesterPath)
-	appLogger.Info(ctx, "Load Harvester Config")
-	handler.inspectConcurrency = conf.InspectConcurrency
-	appLogger.Info(ctx, "Load Concurrency Config")
-	handler.findingClient = newFindingClient(conf.CoreAddr)
-	appLogger.Info(ctx, "Start Finding Client")
-	handler.alertClient = newAlertClient(conf.CoreAddr)
-	appLogger.Info(ctx, "Start Alert Client")
-	handler.osintClient = newOsintClient(conf.DataSourceAPISvcAddr)
-	appLogger.Info(ctx, "Start Osint Client")
+	fc, err := newFindingClient(ctx, conf.CoreAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create finding client, err=%+v", err)
+	}
+	ac, err := newAlertClient(ctx, conf.CoreAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create alert client, err=%+v", err)
+	}
+	oc, err := newOsintClient(ctx, conf.DataSourceAPISvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create osint client, err=%+v", err)
+	}
+	handler := &SQSHandler{
+		findingClient:      fc,
+		alertClient:        ac,
+		osintClient:        oc,
+		harvesterConfig:    newHarvesterConfig(conf.ResultPath, conf.HarvesterPath),
+		inspectConcurrency: conf.InspectConcurrency,
+	}
+
 	f, err := mimosasqs.NewFinalizer(message.SubdomainDataSource, settingURL, conf.CoreAddr, &mimosasqs.DataSourceRecommnend{
 		ScanFailureRisk: fmt.Sprintf("Failed to scan %s, So you are not gathering the latest security threat information.", message.SubdomainDataSource),
 		ScanFailureRecommendation: `Please review the following items and rescan,

--- a/src/subdomain/sqs.go
+++ b/src/subdomain/sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
 )
@@ -16,11 +17,11 @@ type SQSConfig struct {
 	WaitTimeSecond     int32
 }
 
-func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
+func newSQSConsumer(ctx context.Context, conf *SQSConfig) (*worker.Worker, error) {
 
 	client, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.Endpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create a new SQS client, err=%w", err)
 	}
 
 	return &worker.Worker{
@@ -32,5 +33,5 @@ func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: client,
-	}
+	}, nil
 }

--- a/src/subdomain/takeover.go
+++ b/src/subdomain/takeover.go
@@ -12,28 +12,28 @@ import (
 )
 
 func searchTakeover(domain string) takeover {
-	cname, _ := resolveCName(domain)
+	cname := resolveCName(domain)
 	if !zero.IsZeroVal(cname) {
 		return takeover{Domain: domain, CName: cname}
 	}
 	return takeover{}
 }
 
-func resolveCName(domain string) (string, error) {
+func resolveCName(domain string) string {
 	c := new(dns.Client)
 	m := new(dns.Msg)
 
 	m.SetQuestion(dns.Fqdn(domain), dns.TypeCNAME)
 	m.RecursionDesired = true
+	// Only normally accessible domains, exclude temporarily inaccessible ex. service unavailable, are scanned, so error is ignored.
 	r, _, err := c.Exchange(m, net.JoinHostPort("8.8.8.8", "53"))
 	if err != nil {
-		return "", nil
+		return ""
 	}
 	if zero.IsZeroVal(r.Answer) {
-		return "", nil
+		return ""
 	}
-	return r.Answer[0].(*dns.CNAME).Target, nil
-	//	return r.Answer[0].(*dns.CNAME).Target, nil
+	return r.Answer[0].(*dns.CNAME).Target
 }
 
 func (c *takeover) makeFinding(isDown bool, projectID uint32, dataSource string) (*finding.FindingForUpsert, error) {


### PR DESCRIPTION
src/subdomain配下のエラーハンドリング改善しました。

* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしました。
* エラーを握り潰す箇所には妥当性についてのコメントを記載しました。
* 使用していない戻り値のエラーを削除しました。
* スキャンエラー時に発生したエラーの情報をログに出力するようにしました。