### PR TITLE
Improve error handling in website

### DIFF
--- a/src/website/client.go
+++ b/src/website/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/alert"
@@ -11,33 +12,30 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
-	ctx := context.Background()
+func newFindingClient(ctx context.Context, svcAddr string) (finding.FindingServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
 	appLogger.Info(ctx, "Start Finding Client")
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
-	ctx := context.Background()
+func newAlertClient(ctx context.Context, svcAddr string) (alert.AlertServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
 	appLogger.Info(ctx, "Start Alert Client")
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newOsintClient(svcAddr string) osint.OsintServiceClient {
-	ctx := context.Background()
+func newOsintClient(ctx context.Context, svcAddr string) (osint.OsintServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return osint.NewOsintServiceClient(conn)
+	return osint.NewOsintServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/src/website/finding.go
+++ b/src/website/finding.go
@@ -49,6 +49,7 @@ func (s *SQSHandler) putFinding(ctx context.Context, websiteFinding *finding.Fin
 	}
 	if err = s.tagFinding(ctx, res.Finding.ProjectId, res.Finding.FindingId, common.TagWebsite); err != nil {
 		appLogger.Errorf(ctx, "Failed to tag finding. tag: %v, error: %v", common.TagWebsite, err)
+		return err
 	}
 	if err = s.tagFinding(ctx, res.Finding.ProjectId, res.Finding.FindingId, fmt.Sprintf("osint_id:%v", msg.OsintID)); err != nil {
 		appLogger.Errorf(ctx, "Failed to tag finding. tag: %v, error: %v", fmt.Sprintf("osint_id:%v", msg.OsintID), err)

--- a/src/website/main.go
+++ b/src/website/main.go
@@ -123,7 +123,10 @@ func main() {
 		MaxNumberOfMessage: conf.MaxNumberOfMessage,
 		WaitTimeSecond:     conf.WaitTimeSecond,
 	}
-	consumer := newSQSConsumer(ctx, sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create SQS consumer, err=%+v", err)
+	}
 	appLogger.Info(ctx, "Start the website SQS consumer server...")
 	consumer.Start(ctx,
 		mimosasqs.InitializeHandler(

--- a/src/website/sqs.go
+++ b/src/website/sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
@@ -19,14 +20,14 @@ type SQSConfig struct {
 	WaitTimeSecond     int32
 }
 
-func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
+func newSQSConsumer(ctx context.Context, conf *SQSConfig) (*worker.Worker, error) {
 	if conf.Debug == "true" {
 		appLogger.Level(logging.DebugLevel)
 	}
 
 	client, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.SQSEndpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create SQS client, err=%w", err)
 	}
 
 	return &worker.Worker{
@@ -38,5 +39,5 @@ func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: client,
-	}
+	}, nil
 }


### PR DESCRIPTION
src/website配下のエラーハンドリング改善しました。

* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしました。
* finding_tagの登録/更新に失敗した場合にエラーを返すようにしました。
* handleErrorWithUpdateStatusはステータスの更新とエラーのラッピングという二つの責務を持っていたので、見通しをよくするために分割しました。責務に合わせてメソッド名も変更しています。