### PR TITLE
Fix subdomain error handling

### DIFF
--- a/pkg/subdomain/handler.go
+++ b/pkg/subdomain/handler.go
@@ -124,8 +124,8 @@ func (s *SQSHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 				sem.Release(1)
 				wg.Done()
 			}()
-			privateExpose := searchPrivateExpose(h, detectList)
-			takeover := checkTakeover(h)
+			privateExpose := searchPrivateExpose(h, detectList, s.logger)
+			takeover := checkTakeover(h, s.logger)
 			certificateExpiration := privateExpose.checkCertificateExpiration()
 
 			mutex.Lock()

--- a/pkg/subdomain/private_expose.go
+++ b/pkg/subdomain/private_expose.go
@@ -1,12 +1,9 @@
 package subdomain
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
-	"time"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/proto/finding"
@@ -32,26 +29,6 @@ func getHTTPStatus(host, protocol string, logger logging.Logger) (int, string) {
 	}
 	defer res.Body.Close()
 	return res.StatusCode, res.Request.URL.String()
-}
-
-func requestHTTP(host, protocol string, logger logging.Logger) *http.Response {
-	url := fmt.Sprintf("%s://%s", protocol, host)
-	// Only normally accessible URLs, exclude temporarily inaccessible URLs ex. service unavailable, are scanned, so error is ignored.
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		logger.Warnf(context.TODO(), "new request error: %s, url: %s", err.Error(), url)
-		return nil
-	}
-	client := http.Client{
-		Timeout: 5 * time.Second,
-	}
-
-	res, err := client.Do(req)
-	// Timeoutもエラーに入るので、特にログも出さないでスルー(ドメインを見つけてもHTTPで使われているとは限らないため)
-	if err != nil {
-		return nil
-	}
-	return res
 }
 
 func isDetected(host string, detectList *[]string) bool {

--- a/pkg/subdomain/takeover.go
+++ b/pkg/subdomain/takeover.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/proto/finding"
 	"github.com/miekg/dns"
 	"github.com/vikyd/zero"
 )
 
-func checkTakeover(h host) takeover {
+func checkTakeover(h host, logger logging.Logger) takeover {
 	cname := resolveCName(h.HostName)
 	if cname == "" {
 		return takeover{}
@@ -24,7 +25,7 @@ func checkTakeover(h host) takeover {
 	if td != nil {
 		t.Vulnerable = true
 		if td.Type == VHO {
-			t.IsDown = isDownVHODomain(cname, td.Fingerprint)
+			t.IsDown = isDownVHODomain(cname, td.Fingerprint, logger)
 		} else {
 			t.IsDown = h.isDown()
 		}

--- a/pkg/subdomain/takeover_domain.go
+++ b/pkg/subdomain/takeover_domain.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"regexp"
 	"strings"
+
+	"github.com/ca-risken/common/pkg/logging"
 )
 
 type TakeoverType int
@@ -20,18 +22,18 @@ type TakeoverDomain struct {
 	Fingerprint string // how to check whether the subdomain has already been takeovered.
 }
 
-func isDownVHODomain(cname string, fingerprint string) bool {
-	if existsVirtualHost(cname, "http", fingerprint) {
+func isDownVHODomain(cname string, fingerprint string, logger logging.Logger) bool {
+	if existsVirtualHost(cname, "http", fingerprint, logger) {
 		return false
 	}
-	if existsVirtualHost(cname, "https", fingerprint) {
+	if existsVirtualHost(cname, "https", fingerprint, logger) {
 		return false
 	}
 	return true
 }
 
-func existsVirtualHost(cname, protocol, fingerprint string) bool {
-	resp := requestHTTP(cname, protocol)
+func existsVirtualHost(cname, protocol, fingerprint string, logger logging.Logger) bool {
+	resp := requestHTTP(cname, protocol, logger)
 	if resp == nil || resp.Body == nil {
 		return false
 	}

--- a/pkg/subdomain/takeover_domain_test.go
+++ b/pkg/subdomain/takeover_domain_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/ca-risken/common/pkg/logging"
 	"github.com/jarcoal/httpmock"
 )
 
@@ -12,6 +13,7 @@ const (
 )
 
 func TestIsDownVHODomain(t *testing.T) {
+	logger := logging.NewLogger()
 	cases := []struct {
 		name     string
 		input    string
@@ -88,7 +90,7 @@ func TestIsDownVHODomain(t *testing.T) {
 			if td == nil {
 				t.Fatalf("Could not get takeover domain, input=%s", c.input)
 			}
-			got := isDownVHODomain(c.input, td.Fingerprint)
+			got := isDownVHODomain(c.input, td.Fingerprint, logger)
 			if got != c.want {
 				t.Fatalf("Unexpected return: got=%t, want=%t", got, c.want)
 			}


### PR DESCRIPTION
client.Doでのpanicへの対処として、NewRequest時にエラーが発生した場合、ログを出力してnilを返すように修正します。
また、requestHTTP functionがprivate expose以外にもtakeoverで使用されているのでhandlerに移しました。