### PR TITLE
Add GitHub Actions workflow for building and tagging OSINT container on PR events

### DIFF
--- a/.github/workflows/build-pr-osint.yml
+++ b/.github/workflows/build-pr-osint.yml
@@ -1,0 +1,19 @@
+name: Build and Tag Container for PR OSINT
+
+on: 
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  build-pr-osint:
+    uses: ca-risken/.github/.github/workflows/build-pr.yml@main
+    with:
+      runs_on: codebuild-mimosa-osint-pr-runner-${{ github.run_id }}-${{ github.run_attempt }}
+      install_go_version: "1.18.2"
+      golangci_lint_version: "v1.50.1"
+      image_prefix: "multi-arch-test-osint"
+    secrets:
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+      DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}


### PR DESCRIPTION
googleに関連付けられていたcodebuildを置き換えるためにgithub actionsのワークフローを追加します。
awsやcoreのものとgolangのバージョンとimage prefix以外は同じ内容です。